### PR TITLE
ChatInput will always be to the bottom and Suggestions as flexbox rows

### DIFF
--- a/src/Components/Parts/ChatInput.vue
+++ b/src/Components/Parts/ChatInput.vue
@@ -47,7 +47,7 @@
 @import '@/Style/Mixins'
 
 .bottomchat
-    position: fixed
+    position: relative
     bottom: 0
     left: 0
     width: 100%
@@ -57,10 +57,10 @@
     display: flex
 
 .suggestions
-    overflow-x: scroll
-    overflow-y: hidden
     white-space: nowrap
-    -webkit-overflow-scrolling: touch
+    display: flex
+    flex-direction: row
+    flex-wrap: wrap
 
     &::-webkit-scrollbar
         display: none

--- a/src/Components/Parts/ChatInput.vue
+++ b/src/Components/Parts/ChatInput.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="bottomchat">
+    <div ref="chatInput" class="bottomchat" :class="[inputFixed ? 'fixed' : 'relative']">
         <div class="container">
             <!-- Here are the suggestions -->
             <div class="suggestions"><slot /></div>
@@ -43,11 +43,10 @@
     </div>
 </template>
 
-<style lang="sass" scoped>
+<style lang="sass">
 @import '@/Style/Mixins'
 
 .bottomchat
-    position: relative
     bottom: 0
     left: 0
     width: 100%
@@ -117,6 +116,10 @@ export default {
         disabled: {
             type: Boolean,
             default: false
+        },
+        messages: {
+            type: Array,
+            default: () => []
         }
     },
     data(){
@@ -125,7 +128,8 @@ export default {
             microphone: false,
             recognition: null,
             recorder: null,
-            should_listen: false
+            should_listen: false,
+            inputFixed: false
         }
     },
     computed: {
@@ -134,6 +138,10 @@ export default {
         }
     },
     watch: {
+        // eslint-disable-next-line no-unused-vars
+        messages(messages){
+            this.chatInputPosition()
+        },
         /* Toggle microphone */
         microphone(activate){
             if (activate){
@@ -183,7 +191,20 @@ export default {
             else if (this.recorder) this.recorder.stop()
         }
     },
+    mounted(){
+        this.chatInputPosition()
+        window.addEventListener('resize', this.chatInputPosition)
+    },
     methods: {
+        chatInputPosition(){
+            const appChatHeight = document.getElementById('app').clientHeight
+            const bubblesHeight = document.getElementsByClassName('chat-container')[0].clientHeight
+            const chatInput = this.$refs.chatInput.clientHeight
+
+            const spaceForChatInput = appChatHeight - bubblesHeight
+            // console.log(appChatHeight, bubblesHeight, chatInput)
+            this.inputFixed = chatInput < spaceForChatInput
+        },
         listen(){
             if (this.should_listen) this.microphone = true
         },
@@ -192,7 +213,6 @@ export default {
                 this.$emit('submit', submission)
                 this.query = ''
             }
-
             else if (submission.audio) this.$emit('submit', submission)
         }
     }

--- a/src/Components/Rich/Suggestion.vue
+++ b/src/Components/Rich/Suggestion.vue
@@ -15,7 +15,6 @@
 
 .suggestion
     @include reset
-    display: inline-block
     padding: 8px 12px
     border-radius: 40px
     border: 1px solid var(--border)

--- a/src/Views/App.vue
+++ b/src/Views/App.vue
@@ -365,7 +365,7 @@ body
 <style lang="sass" scoped>
 .chat-container
     padding-top: 80px
-    padding-bottom: 125px
+    padding-bottom: 25px
 </style>
 
 <script>

--- a/src/Views/App.vue
+++ b/src/Views/App.vue
@@ -317,7 +317,7 @@
         </div>
 
         <!-- ChatInput is made for submitting queries and displaying suggestions -->
-        <ChatInput ref="input" :disabled="messages.length < 3" @submit="send">
+        <ChatInput ref="input" :disabled="messages.length < 3" :messages="messages" @submit="send">
             <!-- Suggestion chips
                 https://developers.google.com/actions/assistant/responses#suggestion_chips
                 https://cloud.google.com/dialogflow/docs/reference/rest/v2beta1/projects.agent.intents#QuickReplies
@@ -347,12 +347,21 @@
 @import '@/Style/Reset.sass'
 @import '@/Style/Theme.sass'
 
+.relative
+    position: relative
+
+.fixed
+    position: fixed
+
 body
     margin: 0
     padding: 0
     font-family: var(--font)
     font-display: swap
     background-color: var(--background)
+
+#app
+    height: 100vh
 
 .container
     max-width: 500px


### PR DESCRIPTION
The ChatInput will be always in two possible states:

- fixed: to the bottom if you have empty space on the screen to prevent the input to cover messages
- relative: to the other messages to the bottom when you don't have enough space to leave it as fixed

To achieve this ChatInput will listen for two things:

1.  new messages arrived to resize according to the new bubbles height
2. resize event of the screen if the user rotate the screen or resize the browser window

This second check is also useful if the chatbot will be also used in a full screen page.

Here's a quick video preview of this: https://streamable.com/kwgdyh

After having fixed this UX, I also modified the ".suggestion" and ".suggestions" using flexbox styling to make them responsive as in this image:
![](https://i.imgur.com/xzHraYk.png)